### PR TITLE
[SRN-80, 82, 83, 87] Fixed bugs in FedEx Connector modules

### DIFF
--- a/novobi_addons/novobi_shipping_account/views/stock_picking_views.xml
+++ b/novobi_addons/novobi_shipping_account/views/stock_picking_views.xml
@@ -217,7 +217,6 @@
                             <field name="shipping_account_delivery_carrier_ids" invisible="1"/>
                             <field name="provider" string="Provider" invisible="1" />
                             <field name="delivery_carrier_id" string="Shipping Service"
-                                   widget="selection_group"
                                    domain="[('shipping_account_id.id','=',shipping_account_id), ('id', 'in', shipping_account_delivery_carrier_ids)]"
                                    options="{'no_create': True, 'no_open': True}" required="1"
                                    attrs="{'invisible': [('provider', '=', False)], 'required': [('provider', '!=', False)]}"

--- a/novobi_addons/omni_address_checker/models/stock_picking.py
+++ b/novobi_addons/omni_address_checker/models/stock_picking.py
@@ -11,6 +11,9 @@ class StockPicking(models.Model):
 
     def action_validate_address(self):
         fedex = self.env['shipping.account'].search([('provider', '=', 'fedex')], limit=1)
+        if not fedex.fedex_account_number or not fedex.fedex_meter_number or not fedex.fedex_developer_key or not fedex.fedex_developer_password:
+            raise UserError('Please add a FedEx shipping account or complete all FedEx credential fields if you haven\'t done so!')
+
         delivery_address = self.partner_id
 
         request = FedexRequest(self.delivery_carrier_id.get_debug_logger_xml(self),

--- a/novobi_addons/omni_fedex/models/fedex_request.py
+++ b/novobi_addons/omni_fedex/models/fedex_request.py
@@ -73,8 +73,11 @@ class FedexRequest(FedexRequestBase):
         Money.Amount = amount
         self.RequestedShipment.TotalInsuredValue = Money
 
-    def set_residential(self, residential):
+    def set_residential_recipient(self, residential):
         self.RequestedShipment.Recipient.Address.Residential = residential
+
+    def set_residential_shipper(self, residential):
+        self.RequestedShipment.Shipper.Address.Residential = residential
 
     def set_smartpost_detail(self, indicia, ancillary, hubId):
         smart_post_detail = self.factory.SmartPostShipmentDetail()
@@ -402,7 +405,7 @@ class FedexRequest(FedexRequestBase):
                     raise Exception("No rating found")
                 reply = self.response.RateReplyDetails[0]
                 try:
-                    if reply['ServiceType'] == 'FEDEX_GROUND':
+                    if reply['ServiceType'] in ['FEDEX_GROUND', 'GROUND_HOME_DELIVERY']:
                         formatted_response['estimated_delivery_time'] = reply['TransitTime'].replace('_', ' Business ').title()
                     else:
                         formatted_response['estimated_delivery_time'] = reply['DeliveryTimestamp']


### PR DESCRIPTION
Bug fixing decisions:

- SRN-80 & SRN-87: Removed widget="selection_group" and used the default widget of many2one field type to remove the blank selection and synchronize the list of services correctly from Shipping Accounts settings.
- SRN-82: Finished and polished rest of return label feature's code and methods. TODO: create a ticket to customize FedEx Ground as the return service for all shipments.
- SRN-83: With certain services, there is no commit date to guarantee the delivery date -> use estimated date from rate service instead, if there is no commit date from ship service (estimated date taken from rate service will have "(subject to change)" after the date).